### PR TITLE
Change to cross-spawn for scripts.

### DIFF
--- a/packages/@shaizei:scripts/scripts/analyze.js
+++ b/packages/@shaizei:scripts/scripts/analyze.js
@@ -1,6 +1,7 @@
 const analyze = () => {
-  const { spawn } = require('child_process');
-  spawn(
+  const spawn = require('cross-spawn');
+  
+  spawn.sync(
     "./node_modules/@shaizei/webpack-config/node_modules/.bin/webpack-bundle-analyzer build/stats/stats.json build",
     {
       shell: true,

--- a/packages/@shaizei:scripts/scripts/build.js
+++ b/packages/@shaizei:scripts/scripts/build.js
@@ -1,10 +1,10 @@
 const build = () => {
-  const { spawn } = require('child_process');
+  const spawn = require('cross-spawn');
   
   process.env.NODE_ENV = 'production';
   process.env.BABEL_ENV = 'production';
 
-  spawn(
+  spawn.sync(
     "./node_modules/@shaizei/webpack-config/node_modules/.bin/webpack --env=production --hide-modules",
     {
       shell: true,

--- a/packages/@shaizei:scripts/scripts/develop.js
+++ b/packages/@shaizei:scripts/scripts/develop.js
@@ -1,10 +1,10 @@
 const develop = () => {
-  const { spawn } = require('child_process');
+  const spawn = require('cross-spawn');
   
   process.env.NODE_ENV = 'development';
   process.env.BABEL_ENV = 'development';
 
-  spawn(
+  spawn.sync(
     "./node_modules/.bin/webpack-dev-server --hot --inline",
     {
       shell: true,

--- a/packages/@shaizei:scripts/scripts/eslint-prettier-integration.js
+++ b/packages/@shaizei:scripts/scripts/eslint-prettier-integration.js
@@ -1,7 +1,7 @@
 const eslintPrettierIntegration = () => {
-  const { spawn } = require("child_process");
+  const spawn = require('cross-spawn');
 
-  spawn(
+  spawn.sync(
     "./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint --print-config . | ./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint-config-prettier-check",
     {
       shell: true,

--- a/packages/@shaizei:scripts/scripts/lint-fix.js
+++ b/packages/@shaizei:scripts/scripts/lint-fix.js
@@ -1,7 +1,7 @@
 const lintFix = () => {
-  const { spawn } = require("child_process");
+  const spawn = require('cross-spawn');
 
-  spawn(
+  spawn.sync(
     "./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx 'src/'",
     {
       shell: true,

--- a/packages/@shaizei:scripts/scripts/lint.js
+++ b/packages/@shaizei:scripts/scripts/lint.js
@@ -1,7 +1,7 @@
 const lint = () => {
-  const { spawn } = require("child_process");
+  const spawn = require('cross-spawn');
 
-  spawn(
+  spawn.sync(
     "./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint --ext .js --ext .jsx --ext .ts --ext .tsx 'src/'",
     {
       shell: true,

--- a/packages/@shaizei:scripts/scripts/prettier-fix.js
+++ b/packages/@shaizei:scripts/scripts/prettier-fix.js
@@ -1,7 +1,7 @@
 const prettierFix = () => {
-  const { spawn } = require("child_process");
+  const spawn = require('cross-spawn');
 
-  spawn(
+  spawn.sync(
     "./node_modules/@shaizei/prettier-config/node_modules/.bin/prettier --write './src/**/*.{js,jsx,ts,tsx}'",
     {
       shell: true,

--- a/packages/@shaizei:scripts/scripts/prettier.js
+++ b/packages/@shaizei:scripts/scripts/prettier.js
@@ -1,7 +1,7 @@
 const prettier = () => {
-  const { spawn } = require("child_process");
-
-  spawn(
+  const spawn = require('cross-spawn');
+  
+  spawn.sync(
     "./node_modules/@shaizei/prettier-config/node_modules/.bin/prettier --check 'src/**/*.{js,jsx,ts,tsx}'",
     {
       shell: true,

--- a/packages/@shaizei:scripts/scripts/serve.js
+++ b/packages/@shaizei:scripts/scripts/serve.js
@@ -1,6 +1,7 @@
 const serve = () => {
-  const { spawn } = require('child_process');
-  spawn(
+  const spawn = require('cross-spawn');
+  
+  spawn.sync(
     "./node_modules/@shaizei/scripts/node_modules/.bin/serve -s build",
     {
       shell: true,


### PR DESCRIPTION
Instead of using 'child_process', we're converting to 'cross-spawn' for
better cross-platform support.
