### PR TITLE
fix(webpack-config): Fix clean-webpack-plugin API mismatch bug.

### DIFF
--- a/packages/webpack-config/config/webpack.production.js
+++ b/packages/webpack-config/config/webpack.production.js
@@ -34,7 +34,7 @@ const webpackProdConfig = {
     new ManifestPlugin({
       fileName: 'asset-manifest.json',
     }),
-    new CleanWebpackPlugin(['build'], {
+    new CleanWebpackPlugin({
       root: path.resolve(process.cwd()),
       allowExternal: false,
       dry: false,


### PR DESCRIPTION
After upgrading to a major version of `clean-webpack-plugin`,
an API breaking change that it can only take an object as argument (not
the directories array that needs to be cleared) caused this issue.
