### PR TITLE
fix(babel-preset): Fixing corejs versioning issue.

### DIFF
--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -49,7 +49,7 @@ const shaizeiBabelPreset = (context, options = {}) => {
         useBuiltIns: false,
         development: env === 'development' ? true : false,
         throwIfNamespace: true,
-      },  
+      },
     ],
     [
       require.resolve('@babel/preset-env'),
@@ -63,7 +63,8 @@ const shaizeiBabelPreset = (context, options = {}) => {
         forceAllTransforms: false,
         configPath: process.cwd(),
         ignoreBrowserslistConfig: true,
-        shippedProposals: true,  
+        shippedProposals: true,
+        corejs: 2
       }
     ],
   ];


### PR DESCRIPTION
As corejs is not direct dependency of the project, so an update version
of Babel started throwing warning for that.
