### PR TITLE
chore(webpack-config): Add new extensions for webpack absolute imports.

### DIFF
--- a/packages/webpack-config/config/webpack.base.js
+++ b/packages/webpack-config/config/webpack.base.js
@@ -155,7 +155,10 @@ const baseConfig = {
       '.ttf',
       '.css',
       '.scss',
-      '.sass'
+      '.sass',
+      '.png',
+      '.jpg',
+      '.jpeg'
     ],
     alias: {
       src: path.resolve(process.cwd(), 'src')


### PR DESCRIPTION
Add `.jpg`, `.jpeg` and `.png` support for absolute `webpack` imports.
