### PR TITLE
feat(eslint-config): Turn off `prop-types` rule.

### DIFF
--- a/packages/eslint-config/typescriptReact.js
+++ b/packages/eslint-config/typescriptReact.js
@@ -5,6 +5,7 @@ const eslintConfigForTS = {
   },
   rules: {
     'react/jsx-filename-extension': [1, { extensions: ['.tsx', '.ts'] }],
+    'react/prop-types': 0
   },
   plugins: [
     '@typescript-eslint',


### PR DESCRIPTION
As `prop-types` are not required in React-TypeScript projects so turning
it off.
