### PR TITLE
Add separate CSS and JS source-map options.

### DIFF
--- a/packages/webpack-config/config/webpack.base.js
+++ b/packages/webpack-config/config/webpack.base.js
@@ -11,6 +11,7 @@ const shaizeiConfig = loadJSONFIle.sync(path.resolve(process.cwd(), 'shaizeirc.j
 const isProduction = process.env.NODE_ENV === 'production';
 const isTypeScript = shaizeiConfig.hasOwnProperty('typescript') ? shaizeiConfig.typescript : false;
 const shouldUseCSSModules = shaizeiConfig.hasOwnProperty('cssModules') ? shaizeiConfig.cssModules : false;
+const shouldAddCSSSourceMaps = shaizeiConfig.hasOwnProperty('addCSSSourceMaps') ? shaizeiConfig.addCSSSourceMaps : true;
 const fileHandlingLoaders = [
   {
     loader: 'file-loader',
@@ -34,8 +35,8 @@ const styleLoader = {
     attrs: {},
     insertAt: 'top',
     singleton: true,
-    sourceMap: shaizeiConfig.hasOwnProperty('addSourceMaps') ? shaizeiConfig.addSourceMaps : true,
-    convertToAbsoluteUrls: shaizeiConfig.hasOwnProperty('addSourceMaps') ? shaizeiConfig.addSourceMaps : true,
+    sourceMap: shouldAddCSSSourceMaps,
+    convertToAbsoluteUrls: shouldAddCSSSourceMaps,
   },
 };
 
@@ -97,7 +98,7 @@ const baseConfig = {
               import: true,
               modules: shouldUseCSSModules,
               localIdentName: '[name]-[hash:base64:5]',
-              sourceMap: shaizeiConfig.hasOwnProperty('addSourceMaps') ? shaizeiConfig.addSourceMaps : true,
+              sourceMap: shouldAddCSSSourceMaps,
               camelCase: shouldUseCSSModules,
               importLoaders: false,
               exportOnlyLocals: false,
@@ -115,7 +116,7 @@ const baseConfig = {
           {
             loader: 'sass-loader',
             options: {
-              sourceMap: shaizeiConfig.hasOwnProperty('addSourceMaps') ? shaizeiConfig.addSourceMaps : true,
+              sourceMap: shouldAddCSSSourceMaps,
             }
           }
         ],

--- a/packages/webpack-config/config/webpack.production.js
+++ b/packages/webpack-config/config/webpack.production.js
@@ -9,14 +9,15 @@ const loadJSONFIle = require('load-json-file');
 
 const shaizeiConfig = loadJSONFIle.sync(path.resolve(process.cwd(), 'shaizeirc.json'));
 
-const shouldAddSourceMaps = shaizeiConfig.hasOwnProperty('addSourceMaps') ? shaizeiConfig.addSourceMaps : true;
+const shouldAddJSSourceMaps = shaizeiConfig.hasOwnProperty('addJSSourceMaps') ? shaizeiConfig.addJSSourceMaps : true;
+const shouldAddCSSSourceMaps = shaizeiConfig.hasOwnProperty('addCSSSourceMaps') ? shaizeiConfig.addCSSSourceMaps : true;
 const isTypeScript = shaizeiConfig.hasOwnProperty('typescript') ? shaizeiConfig.typescript : false;
 const prodSourceMap = shaizeiConfig.hasOwnProperty('webpackProdSourceMap') ? shaizeiConfig.webpackProdSourceMap : 'source-map';
 
 const webpackProdConfig = {
   mode: 'production',
   bail: true,
-  devtool: shouldAddSourceMaps ? prodSourceMap : false,
+  devtool: shouldAddJSSourceMaps ? prodSourceMap : false,
   entry: path.resolve(process.cwd(), 'src', `index.${isTypeScript ? 'tsx' : 'jsx'}`),
   output: {
     filename: 'static/js/[name].[chunkhash:8].js',
@@ -70,13 +71,13 @@ const webpackProdConfig = {
         },
         cache: true,
         parallel: true,
-        sourceMap: shouldAddSourceMaps
+        sourceMap: shouldAddJSSourceMaps
       }),
       new OptimizeCssAssetsPlugin({
         assetNameRegExp: /\.css$/g,
         cssProcessor: require('cssnano'),
         cssProcessorOptions: {
-          map: shouldAddSourceMaps ? {
+          map: shouldAddCSSSourceMaps ? {
             inline: false,
             annotation: true
           } : false,


### PR DESCRIPTION
Instead of `addSourceMaps`, `shaizei` now includes separate source-map
options for CSS & JS.

- addCSSSourceMaps: `true` or `false`
- addJSSourceMaps: `true` or `false`