### PR TITLE
Fix logging of port-fallback in `shaizei build`.

### DIFF
--- a/packages/webpack-config/config/webpack.devServer.js
+++ b/packages/webpack-config/config/webpack.devServer.js
@@ -16,7 +16,7 @@ const overlayConfig = {
 
 const freePort = getFreePort(defaultPort);
 
-if (defaultPort !== freePort) {
+if (defaultPort !== freePort && process.env.NODE_ENV === 'development') {
   console.log(
     `\nYour preferred default port (${defaultPort}) is already busy, starting server at ${freePort}.`
   );


### PR DESCRIPTION
While running `shaizei build`, port-fallback (if default port is busy)
still gets logged, this is fixed by restricting it to print the
port-fallback only in case of `shaizei develop`.
