### PR TITLE
Ignore linting for `*.d.ts` files.

### DIFF
--- a/packages/eslint-config/.eslintignore
+++ b/packages/eslint-config/.eslintignore
@@ -17,3 +17,4 @@ webpack.config.js
 .prettierrc.js
 babel.config.js
 .babelrc.js
+*.d.ts


### PR DESCRIPTION
There's no use of running linter on TypeScript type definitions. 🤟🏼