### PR TITLE
Remove `ts-loader` from TS build pipeline.

### DIFF
--- a/packages/webpack-config/config/webpack.base.js
+++ b/packages/webpack-config/config/webpack.base.js
@@ -48,12 +48,6 @@ if (isProduction) {
   });
 }
 
-if (isTypeScript) {
-  primaryJSTSxLoaders.push({
-    loader: require.resolve('ts-loader')
-  });
-}
-
 if (!isCI) {
   conditionalPlugins.push(new WebpackBar());
 }


### PR DESCRIPTION
As we're now using Babel 7 to convert TypeScript to JavaScript so their
is no need to have `ts-loader`.
