### PR TITLE
Add direct support of `typescript` and `emotion`.

### DIFF
--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -31,36 +31,6 @@ For JavaScript projects:
   }
 ```
 
-For TypeScript projects:
-
-If you're using this preset in a TypeScript project and want Babel to transpile your TypeScript code, then pass the `typescript` option as follows:
-
-```javascript
-  {
-    "presets": [
-      "@shaizei/babel-preset",
-      {
-        typescript: true
-      }
-    ]
-  }
-```
-
-For Emotion projects:
-
-If you're using [Emotion](https://emotion.sh) and want to add support of Emotion's CSS prop, the pass the `emotion` option as follows:
-
-```javascript
-  {
-    "presets": [
-      "@shaizei/babel-preset",
-      {
-        emotion: true
-      }
-    ]
-  }
-```
-
 ## Override Default Config
 
 If you want to override the default configuration, then extend `.babelrc` normally.

--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -1,6 +1,12 @@
+const loadJSONFIle = require('load-json-file');
+const path = require('path');
+
 const shaizeiBabelPreset = (context, options = {}) => {
-  
   const env = process.env.BABEL_ENV || process.env.NODE_ENV;
+  const shaizeiConfig = loadJSONFIle.sync(path.resolve(process.cwd(), 'shaizeirc.json'));
+
+  const isTypeScript = shaizeiConfig.hasOwnProperty('typescript') ? shaizeiConfig.typescript : false;
+  const isEmotion = shaizeiConfig.hasOwnProperty('emotion') ? shaizeiConfig.emotion : false;
 
   const browserlistDev = [
     'last 2 chrome versions',
@@ -60,11 +66,11 @@ const shaizeiBabelPreset = (context, options = {}) => {
     ],
   ];
 
-  if (options.typescript && options.typescript === true) {
+  if (isTypeScript) {
     presets.push(require.resolve('@babel/preset-typescript'));
   }
   // keep emotion preset at the end otherwise it won't work :|
-  if (options.emotion && options.emotion === true) {
+  if (isEmotion) {
     presets.push(
       [
         require.resolve('@emotion/babel-preset-css-prop'),

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -33,7 +33,8 @@
     "@emotion/babel-preset-css-prop": "^10.0.9",
     "babel-plugin-emotion": "^10.0.9",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "react-hot-loader": "^4.8.0"
+    "react-hot-loader": "^4.8.0",
+    "load-json-file": "^5.2.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Instead of configuring babel-preset (for TypeScript and/or Emotion), now
those options are unified in `shaizeirc.json` file.
