### PR TITLE
Remove types from base `tsconfig.json`.

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -39,11 +39,6 @@
     "lib": [
       "esnext",
       "dom"
-    ],
-    "types": [
-      "react",
-      "react-dom",
-      "react-redux"
     ]
   },
   "typeAcquisition": {


### PR DESCRIPTION
As types varies from project to project, so every TS-React project should add the types it needs.
Moving the types to `shaizei-starter-typescript`.
