### PR TITLE
Removed `watchContentBase` from devServer.

### DIFF
--- a/packages/webpack-config/config/webpack.devServer.js
+++ b/packages/webpack-config/config/webpack.devServer.js
@@ -24,7 +24,6 @@ if (defaultPort !== freePort && process.env.NODE_ENV === 'development') {
 
 const serverConfig = {
   open: true,
-  watchContentBase: true,
   clientLogLevel: 'none',
   hot: true,
   publicPath: '/',


### PR DESCRIPTION
As we're not serving any static directory so removing
`watchContentBase`. Enabling this flag breaks HMR with latest
`webpack-dev-server`.
