### PR TITLE
Add `type-check` script for TS projects.

### DIFF
--- a/packages/scripts/index.js
+++ b/packages/scripts/index.js
@@ -7,6 +7,7 @@ const eslintPrettierIntegration = require('./scripts/eslint-prettier-integration
 const prettier = require('./scripts/prettier');
 const lintFix = require('./scripts/lint-fix');
 const prettierFix = require('./scripts/prettier-fix');
+const typeCheck = require('./scripts/type-check');
 
 module.exports = {
   lint,
@@ -17,5 +18,6 @@ module.exports = {
   eslintPrettierIntegration,
   prettier,
   lintFix,
-  prettierFix
+  prettierFix,
+  typeCheck,
 };

--- a/packages/scripts/scripts/type-check.js
+++ b/packages/scripts/scripts/type-check.js
@@ -1,0 +1,12 @@
+const checkType = () => {
+  const spawn = require('cross-spawn');
+
+  spawn.sync('tsc',
+    {
+      shell: true,
+      stdio: 'inherit'
+    }
+  )
+}
+
+module.exports = checkType;


### PR DESCRIPTION
As we're using Babel 7 to transpile TS code. So, we need to add a
separate script to type-check our code.
