### PR TITLE
Updating Prettier version to 1.17.0

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^1.6.0",
-    "prettier": "^1.16.4",
+    "prettier": "^1.17.0",
     "typescript": "^3.3.4000"
   },
   "peerDependencies": {

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -30,7 +30,7 @@
   ],
   "homepage": "https://www.npmjs.com/package/@shaizei/prettier-config",
   "dependencies": {
-    "prettier": "^1.16.4"
+    "prettier": "^1.17.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Updating Prettier version to `1.17.0` to support `quoteProps`.