### PR TITLE
Fix entry-level missing validation.

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -55,7 +55,7 @@ program
     '\n'
   );
   require('@shaizei/scripts').develop();
-})
+});
 
 program
 .command('lint')
@@ -176,6 +176,7 @@ program
 .alias('tc')
 .description(`Type-Check your TypeScript code.`)
 .action(() => {
+  entryValidation();
   validateIfTypeScriptApp();
   console.log(
     '\n' +


### PR DESCRIPTION
`type-check` script must check for entry-level validation first, and
then should go for checking TypeScript project.
