### PR TITLE
Remove `babel-plugin-emotion` completely.

### DIFF
--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -32,7 +32,6 @@
     "@babel/runtime": "^7.4.2",
     "@babel/runtime-corejs2": "^7.4.2",
     "@emotion/babel-preset-css-prop": "^10.0.9",
-    "babel-plugin-emotion": "^10.0.9",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "react-hot-loader": "^4.8.0"
   },


### PR DESCRIPTION
As sanity is done, it is safe to remove `babel-plugin-emotion`
completely.
