### PR TITLE
Centralize more-reusable code, reduce redundancy.

### DIFF
--- a/packages/cli/utils/createApp.js
+++ b/packages/cli/utils/createApp.js
@@ -1,8 +1,8 @@
 const fs = require('fs');
-const path = require('path');
 const del = require('del');
 const { spawnSync } = require('child_process');
 const chalk = require('chalk');
+const { resolveCWD } = require('@shaizei/helpers');
 const renameClonedRepo = require('./renameClonedRepo');
 
 const createApp = (projectName ,isTypeScript, jsStarterName, tsStarterName, jsStarterURL, tsStarterURL, spawnOptions, prefix) => {
@@ -13,14 +13,15 @@ const createApp = (projectName ,isTypeScript, jsStarterName, tsStarterName, jsSt
     renameClonedRepo(projectName, jsStarterName, jsStarterURL, spawnOptions);
   }
   del.sync(
-    path.resolve(process.cwd(), projectName, '.git')
+    resolveCWD(projectName, '.git')
   );
-  const packageJSON = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), projectName, 'package.json')));
+  const pathToPackageJSON = resolveCWD(projectName, 'package.json');
+  const packageJSON = JSON.parse(fs.readFileSync(pathToPackageJSON));
   packageJSON.name = projectName;
   delete packageJSON.description;
   delete packageJSON.author;
   fs.writeFileSync(
-    path.resolve(process.cwd(), projectName, 'package.json'),
+    pathToPackageJSON,
     JSON.stringify(packageJSON, null, 2)
   );
   process.chdir(projectName);

--- a/packages/cli/utils/renameClonedRepo.js
+++ b/packages/cli/utils/renameClonedRepo.js
@@ -1,12 +1,12 @@
 const fs = require('fs');
-const path = require('path');
 const { spawnSync } = require('child_process');
+const { resolveCWD } = require('@shaizei/helpers');
 
 const renameClonedRepo = (projectName, starterName, starterURL, spawnOptions) => {
   spawnSync(`git clone ${starterURL}`, spawnOptions);
   fs.renameSync(
-    path.resolve(process.cwd(), starterName),
-    path.resolve(process.cwd(), projectName)
+    resolveCWD(starterName),
+    resolveCWD(projectName)
   );
 }
 

--- a/packages/cli/utils/validateOpinions.js
+++ b/packages/cli/utils/validateOpinions.js
@@ -1,16 +1,15 @@
-const path = require('path');
 const fs = require('fs');
 const chalk = require('chalk');
-const { readShaizeiConfig, shaizeiConfigProps } = require('@shaizei/helpers');
-
-const pathToShaizeiConfig = path.resolve(process.cwd(), 'shaizeirc.json');
-const pathToSrcDir = path.resolve(process.cwd(), 'src');
-const pathToIndexJSX = path.resolve(pathToSrcDir, 'index.jsx');
-const pathToIndexTSX = path.resolve(pathToSrcDir, 'index.tsx');
-const pathToIndexHTML = path.resolve(pathToSrcDir, 'index.html');
-const pathToFaviconICO = path.resolve(pathToSrcDir, 'assets', 'favicon.ico');
-const pathToBuild = path.resolve(process.cwd(), 'build');
-const pathToStatsJSON = path.resolve(pathToBuild, 'stats', 'stats.json');
+const { readShaizeiConfig, shaizeiConfigProps, resolveCWD, commonIdent } = require('@shaizei/helpers');
+const { src, indexJSX, indexTSX, indexHTML, assets, faviconICO, shaizeiRC, build, stats, statsJSON } = commonIdent;
+const pathToShaizeiConfig = resolveCWD(shaizeiRC);
+const pathToSrcDir = resolveCWD(src);
+const pathToIndexJSX = resolveCWD(src, indexJSX);
+const pathToIndexTSX = resolveCWD(src, indexTSX);
+const pathToIndexHTML = resolveCWD(src, indexHTML);
+const pathToFaviconICO = resolveCWD(src, assets, faviconICO);
+const pathToBuild = resolveCWD(build);
+const pathToStatsJSON = resolveCWD(build, stats, statsJSON);
 
 validateIfTypeScriptApp = () => {
   if (!readShaizeiConfig(shaizeiConfigProps.typescript)) {

--- a/packages/helpers/index.js
+++ b/packages/helpers/index.js
@@ -1,7 +1,11 @@
 const readShaizeiConfig = require('./lib/shaizeirc/readShaizeiConfig');
 const shaizeiConfigProps = require('./lib/shaizeirc/shaizeiConfigProps');
+const resolveCWD = require('./lib/path/resolveCWD');
+const commonIdent = require('./lib/commonIdent');
 
 module.exports = {
   readShaizeiConfig,
   shaizeiConfigProps,
+  resolveCWD,
+  commonIdent,
 };

--- a/packages/helpers/lib/commonIdent.js
+++ b/packages/helpers/lib/commonIdent.js
@@ -1,0 +1,15 @@
+const commonIdent = {
+  indexJSX: 'index.jsx',
+  indexTSX: 'index.tsx',
+  indexHTML: 'index.html',
+  src: 'src',
+  shaizeiRC: 'shaizeirc.json',
+  build: 'build',
+  assets: 'assets',
+  stats: 'stats',
+  statsJSON: 'stats.json',
+  faviconICO: 'favicon.ico',
+  report: 'report.html',
+};
+
+module.exports = commonIdent;

--- a/packages/helpers/lib/path/resolveCWD.js
+++ b/packages/helpers/lib/path/resolveCWD.js
@@ -1,0 +1,4 @@
+const path = require('path');
+
+const resolveCWD = (...pathsArr) => path.resolve(process.cwd(), ...pathsArr);
+module.exports = resolveCWD;

--- a/packages/helpers/lib/shaizeirc/readShaizeiConfig.js
+++ b/packages/helpers/lib/shaizeirc/readShaizeiConfig.js
@@ -1,10 +1,10 @@
-const path = require('path');
 const loadJSONFIle = require('load-json-file');
 const defaultShaizeiConfig = require('./defaultshaizeiConfig');
-
+const resolveCWD = require('../path/resolveCWD');
+const { shaizeiRC } = require('../commonIdent');
 
 const readShaizeiConfig = property => {
-  const pathToShaizeiConfig = path.resolve(process.cwd(), 'shaizeirc.json');
+  const pathToShaizeiConfig = resolveCWD(shaizeiRC);
   const shaizeiConfig = loadJSONFIle.sync(pathToShaizeiConfig);
   return shaizeiConfig.hasOwnProperty(property)
     ? shaizeiConfig[property]

--- a/packages/scripts/lib/spawnOptions.js
+++ b/packages/scripts/lib/spawnOptions.js
@@ -1,0 +1,6 @@
+const spawnOptions = {
+  shell: true,
+  stdio: 'inherit'
+};
+
+module.exports = spawnOptions;

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@shaizei/babel-preset": "^0.1.0-beta.8",
     "@shaizei/eslint-config": "^0.1.0-beta.8",
+    "@shaizei/helpers": "^0.1.0-beta.8",
     "cross-spawn": "^6.0.5",
     "eslint": "^5.15.3",
     "serve": "^10.1.2",

--- a/packages/scripts/scripts/analyze.js
+++ b/packages/scripts/scripts/analyze.js
@@ -1,12 +1,12 @@
 const analyze = () => {
   const spawn = require('cross-spawn');
+  const { commonIdent } = require('@shaizei/helpers');
+  const spawnOptions = require('../lib/spawnOptions');
+  const { stats, build, statsJSON } = commonIdent;
   
   spawn.sync(
-    "./node_modules/@shaizei/webpack-config/node_modules/.bin/webpack-bundle-analyzer build/stats/stats.json build",
-    {
-      shell: true,
-      stdio: 'inherit'
-    }
+    `./node_modules/@shaizei/webpack-config/node_modules/.bin/webpack-bundle-analyzer ${build}/${stats}/${statsJSON} ${build}`,
+    spawnOptions
   );
 };
 

--- a/packages/scripts/scripts/build.js
+++ b/packages/scripts/scripts/build.js
@@ -1,15 +1,13 @@
 const build = () => {
   const spawn = require('cross-spawn');
-  
+  const spawnOptions = require('../lib/spawnOptions');
+
   process.env.NODE_ENV = 'production';
   process.env.BABEL_ENV = 'production';
 
   spawn.sync(
-    "./node_modules/@shaizei/webpack-config/node_modules/.bin/webpack --env=production --hide-modules",
-    {
-      shell: true,
-      stdio: 'inherit'
-    }
+    './node_modules/@shaizei/webpack-config/node_modules/.bin/webpack --env=production --hide-modules',
+    spawnOptions
   );
 };
 

--- a/packages/scripts/scripts/develop.js
+++ b/packages/scripts/scripts/develop.js
@@ -1,15 +1,13 @@
 const develop = () => {
   const spawn = require('cross-spawn');
-  
+  const spawnOptions = require('../lib/spawnOptions');
+
   process.env.NODE_ENV = 'development';
   process.env.BABEL_ENV = 'development';
 
   spawn.sync(
-    "./node_modules/.bin/webpack-dev-server --hot --inline",
-    {
-      shell: true,
-      stdio: 'inherit'
-    }
+    './node_modules/.bin/webpack-dev-server --hot --inline',
+    spawnOptions
   );
 };
 

--- a/packages/scripts/scripts/eslint-prettier-integration.js
+++ b/packages/scripts/scripts/eslint-prettier-integration.js
@@ -1,12 +1,10 @@
 const eslintPrettierIntegration = () => {
   const spawn = require('cross-spawn');
+  const spawnOptions = require('../lib/spawnOptions');
 
   spawn.sync(
-    "./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint --print-config . | ./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint-config-prettier-check",
-    {
-      shell: true,
-      stdio: "inherit"
-    }
+    './node_modules/@shaizei/eslint-config/node_modules/.bin/eslint --print-config . | ./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint-config-prettier-check',
+    spawnOptions
   );
 };
 

--- a/packages/scripts/scripts/lint-fix.js
+++ b/packages/scripts/scripts/lint-fix.js
@@ -1,12 +1,12 @@
 const lintFix = () => {
   const spawn = require('cross-spawn');
+  const spawnOptions = require('../lib/spawnOptions');
+  const { commonIdent } = require('@shaizei/helpers');
+  const { src } = commonIdent;
 
   spawn.sync(
-    "./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx 'src/'",
-    {
-      shell: true,
-      stdio: "inherit"
-    }
+    `./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx '${src}/'`,
+    spawnOptions
   );
 };
 

--- a/packages/scripts/scripts/lint.js
+++ b/packages/scripts/scripts/lint.js
@@ -1,12 +1,12 @@
 const lint = () => {
   const spawn = require('cross-spawn');
+  const { commonIdent } = require('@shaizei/helpers');
+  const spawnOptions = require('../lib/spawnOptions');
+  const { src } = commonIdent;
 
   spawn.sync(
-    "./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint --ext .js --ext .jsx --ext .ts --ext .tsx 'src/'",
-    {
-      shell: true,
-      stdio: "inherit"
-    }
+    `./node_modules/@shaizei/eslint-config/node_modules/.bin/eslint --ext .js --ext .jsx --ext .ts --ext .tsx '${src}/'`,
+    spawnOptions
   );
 };
 

--- a/packages/scripts/scripts/prettier-fix.js
+++ b/packages/scripts/scripts/prettier-fix.js
@@ -1,12 +1,12 @@
 const prettierFix = () => {
   const spawn = require('cross-spawn');
+  const { commonIdent } = require('@shaizei/helpers');
+  const spawnOptions = require('../lib/spawnOptions');
+  const { src } = commonIdent;
 
   spawn.sync(
-    "./node_modules/@shaizei/prettier-config/node_modules/.bin/prettier --write './src/**/*.{js,jsx,ts,tsx}'",
-    {
-      shell: true,
-      stdio: "inherit"
-    }
+    `./node_modules/@shaizei/prettier-config/node_modules/.bin/prettier --write './${src}/**/*.{js,jsx,ts,tsx}'`,
+    spawnOptions
   );
 };
 

--- a/packages/scripts/scripts/prettier.js
+++ b/packages/scripts/scripts/prettier.js
@@ -1,12 +1,12 @@
 const prettier = () => {
   const spawn = require('cross-spawn');
+  const { commonIdent } = require('@shaizei/helpers');
+  const spawnOptions = require('../lib/spawnOptions');
+  const { src } = commonIdent;
   
   spawn.sync(
-    "./node_modules/@shaizei/prettier-config/node_modules/.bin/prettier --check 'src/**/*.{js,jsx,ts,tsx}'",
-    {
-      shell: true,
-      stdio: "inherit"
-    }
+    `./node_modules/@shaizei/prettier-config/node_modules/.bin/prettier --check '${src}/**/*.{js,jsx,ts,tsx}'`,
+    spawnOptions
   );
 };
 

--- a/packages/scripts/scripts/serve.js
+++ b/packages/scripts/scripts/serve.js
@@ -1,12 +1,12 @@
 const serve = () => {
   const spawn = require('cross-spawn');
+  const { commonIdent } = require('@shaizei/helpers');
+  const spawnOptions = require('../lib/spawnOptions');
+  const { build } = commonIdent;
   
   spawn.sync(
-    "./node_modules/@shaizei/scripts/node_modules/.bin/serve -s build",
-    {
-      shell: true,
-      stdio: 'inherit'
-    }
+    `./node_modules/@shaizei/scripts/node_modules/.bin/serve -s ${build}`,
+    spawnOptions
   );
 };
 

--- a/packages/scripts/scripts/type-check.js
+++ b/packages/scripts/scripts/type-check.js
@@ -1,12 +1,7 @@
 const checkType = () => {
   const spawn = require('cross-spawn');
-
-  spawn.sync('tsc',
-    {
-      shell: true,
-      stdio: 'inherit'
-    }
-  )
-}
+  const spawnOptions = require('../lib/spawnOptions');
+  spawn.sync('tsc' ,spawnOptions);
+};
 
 module.exports = checkType;

--- a/packages/webpack-config/config/webpack.base.js
+++ b/packages/webpack-config/config/webpack.base.js
@@ -10,7 +10,8 @@ const isProduction = process.env.NODE_ENV === 'production';
 const shouldUseCSSModules = readShaizeiConfig(shaizeiConfigProps.cssModules);
 const shouldAddCSSSourceMaps = readShaizeiConfig(shaizeiConfigProps.addCSSSourceMaps);
 const conditionalPlugins = [];
-const srcDir = resolveCWD(commonIdent.src);
+const { src, build, indexHTML, assets, faviconICO } = commonIdent;
+const srcDir = resolveCWD(src);
 const fileHandlingLoaders = [
   {
     loader: 'file-loader',
@@ -52,10 +53,10 @@ if (!isCI) {
 const baseConfig = {
   context: srcDir,
   entry: {
-    main:  resolveCWD(commonIdent.src, `index.${readShaizeiConfig(shaizeiConfigProps.typescript) ? 'tsx' : 'jsx'}`),
+    main:  resolveCWD(src, `index.${readShaizeiConfig(shaizeiConfigProps.typescript) ? 'tsx' : 'jsx'}`),
   },
   output: {
-    path: resolveCWD(commonIdent.build),
+    path: resolveCWD(build),
     filename: 'app.bundle.js',
   },
   plugins: [
@@ -65,9 +66,9 @@ const baseConfig = {
     }),
     new HtmlWebpackPlugin({
       title: readShaizeiConfig(shaizeiConfigProps.title),
-      filename: commonIdent.indexHTML,
-      template: resolveCWD(commonIdent.src, commonIdent.indexHTML),
-      favicon: resolveCWD(commonIdent.src, commonIdent.assets, commonIdent.faviconICO),
+      filename: indexHTML,
+      template: resolveCWD(src, indexHTML),
+      favicon: resolveCWD(src, assets, faviconICO),
       inject: true,
       meta: {},
       minify: isProduction,

--- a/packages/webpack-config/config/webpack.base.js
+++ b/packages/webpack-config/config/webpack.base.js
@@ -1,16 +1,16 @@
-const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const DirectoryNamedWebpackPlugin = require('directory-named-webpack-plugin');
 const WebpackBar = require('webpackbar');
 const { isCI } = require('ci-info');
-const { readShaizeiConfig, shaizeiConfigProps } = require('@shaizei/helpers');
+const { readShaizeiConfig, shaizeiConfigProps, resolveCWD, commonIdent } = require('@shaizei/helpers');
 
 const isProduction = process.env.NODE_ENV === 'production';
 const shouldUseCSSModules = readShaizeiConfig(shaizeiConfigProps.cssModules);
 const shouldAddCSSSourceMaps = readShaizeiConfig(shaizeiConfigProps.addCSSSourceMaps);
 const conditionalPlugins = [];
+const srcDir = resolveCWD(commonIdent.src);
 const fileHandlingLoaders = [
   {
     loader: 'file-loader',
@@ -50,12 +50,12 @@ if (!isCI) {
 }
 
 const baseConfig = {
-  context: path.resolve(process.cwd(), 'src'),
+  context: srcDir,
   entry: {
-    main:  path.resolve(process.cwd(), 'src', `index.${readShaizeiConfig(shaizeiConfigProps.typescript) ? 'tsx' : 'jsx'}`)
+    main:  resolveCWD(commonIdent.src, `index.${readShaizeiConfig(shaizeiConfigProps.typescript) ? 'tsx' : 'jsx'}`),
   },
   output: {
-    path: path.resolve(process.cwd(), 'build'),
+    path: resolveCWD(commonIdent.build),
     filename: 'app.bundle.js',
   },
   plugins: [
@@ -65,9 +65,9 @@ const baseConfig = {
     }),
     new HtmlWebpackPlugin({
       title: readShaizeiConfig(shaizeiConfigProps.title),
-      filename: 'index.html',
-      template: path.resolve(process.cwd(), 'src', 'index.html'),
-      favicon: path.resolve(process.cwd(), 'src', 'assets', 'favicon.ico'),
+      filename: commonIdent.indexHTML,
+      template: resolveCWD(commonIdent.src, commonIdent.indexHTML),
+      favicon: resolveCWD(commonIdent.src, commonIdent.assets, commonIdent.faviconICO),
       inject: true,
       meta: {},
       minify: isProduction,
@@ -159,12 +159,12 @@ const baseConfig = {
       '.jpeg'
     ],
     alias: {
-      src: path.resolve(process.cwd(), 'src')
+      src: srcDir,
     },
-    modules: [path.resolve(process.cwd(), 'src'), 'node_modules'],
+    modules: [srcDir, 'node_modules'],
     plugins: [new DirectoryNamedWebpackPlugin({
       honorIndex: true,
-      include: path.resolve(process.cwd(), 'src')
+      include: srcDir
     })],
   },
 };

--- a/packages/webpack-config/config/webpack.devServer.js
+++ b/packages/webpack-config/config/webpack.devServer.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const { readShaizeiConfig, shaizeiConfigProps } = require('@shaizei/helpers');
 const getFreePort = require('../utils/getFreePort.js');
 

--- a/packages/webpack-config/config/webpack.development.js
+++ b/packages/webpack-config/config/webpack.development.js
@@ -1,6 +1,5 @@
-const path = require('path');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-const { readShaizeiConfig, shaizeiConfigProps } = require('@shaizei/helpers');
+const { readShaizeiConfig, shaizeiConfigProps, resolveCWD } = require('@shaizei/helpers');
 const devServerConfig = require('./webpack.devServer.js');
 
 const conditionalPlugins = [];
@@ -11,7 +10,7 @@ if (
   ) {
   conditionalPlugins.push(
     new ForkTsCheckerWebpackPlugin({
-      tsconfig: path.resolve(process.cwd(), 'tsconfig.json'),
+      tsconfig: resolveCWD('tsconfig.json'),
       useTypescriptIncrementalApi: true,
       measureCompilationTime: true,
       formatter: 'codeframe',

--- a/packages/webpack-config/config/webpack.production.js
+++ b/packages/webpack-config/config/webpack.production.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
@@ -6,18 +5,19 @@ const TerserPlugin = require('terser-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { isCI } = require('ci-info');
-const { readShaizeiConfig, shaizeiConfigProps } = require('@shaizei/helpers');
+const { readShaizeiConfig, shaizeiConfigProps, resolveCWD, commonIdent } = require('@shaizei/helpers');
 
 const shouldAddJSSourceMaps = readShaizeiConfig(shaizeiConfigProps.addJSSourceMaps);
 const conditionalPlugins = [];
+const { stats, report, statsJSON, src } = commonIdent;
 
 if (!isCI) {
   conditionalPlugins.push(
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',
       generateStatsFile: true,
-      reportFilename: 'stats/report.html',
-      statsFilename: 'stats/stats.json',
+      reportFilename: `${stats}/${report}`,
+      statsFilename: `${stats}/${statsJSON}`,
       openAnalyzer: false,
     })
   );
@@ -27,7 +27,7 @@ const webpackProdConfig = {
   mode: 'production',
   bail: true,
   devtool: shouldAddJSSourceMaps ? readShaizeiConfig(shaizeiConfigProps.webpackProdSourceMap) : false,
-  entry: path.resolve(process.cwd(), 'src', `index.${readShaizeiConfig(shaizeiConfigProps.typescript) ? 'tsx' : 'jsx'}`),
+  entry: resolveCWD(src, `index.${readShaizeiConfig(shaizeiConfigProps.typescript) ? 'tsx' : 'jsx'}`),
   output: {
     filename: 'static/js/[name].[chunkhash:8].js',
     chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
@@ -39,7 +39,7 @@ const webpackProdConfig = {
       fileName: 'asset-manifest.json',
     }),
     new CleanWebpackPlugin({
-      root: path.resolve(process.cwd()),
+      root: resolveCWD(),
       allowExternal: false,
       dry: false,
       watch: false,


### PR DESCRIPTION
Took following measures of reducing redundancy.

1) Created schema of common file names and used that throughout the
packages.
2) Instead of repeating `path.resolve(process.cwd(),)`, created a helper
for that and used throughout the packages.
