### PR TITLE
fix(typescript-config): Fix the `outDir` flag of tsconfig options.

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -26,7 +26,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
-    "outDir": "dist",
+    "outDir": "build",
     "removeComments": true,
     "resolveJsonModule": true,
     "strict": true,


### PR DESCRIPTION
As we've streamlind output bundle directory as `build` so fixing
`tsconfig` options where it was `dist` by mistake.
